### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1665,7 +1665,7 @@
 		<jetty.version>6.1.8</jetty.version>
 		<clickstream.version>1.0.2</clickstream.version>
 		<commons.beanutils.version>1.7.0</commons.beanutils.version>
-		<commons.collections.version>3.2</commons.collections.version>
+		<commons.collections.version>3.2.2</commons.collections.version>
 		<commons.dbcp.version>1.2.2</commons.dbcp.version>
 		<commons.fileupload.version>1.1.1</commons.fileupload.version>
 		<commons.io.version>1.3.2</commons.io.version>


### PR DESCRIPTION
Version 3.2 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/